### PR TITLE
Create function to set detection threshold for instance segmentation

### DIFF
--- a/pixellib/instance.py
+++ b/pixellib/instance.py
@@ -55,12 +55,11 @@ class instance_segmentation():
 
         self.model_dir = os.getcwd()
 
-    def load_model(self, model_path):
+    def load_model(self, model_path, confidence= None):
         self.model = MaskRCNN(mode = "inference", model_dir = self.model_dir, config = coco_config)
         self.model.load_weights(model_path, by_name= True)
-
-    def set_detection_confidence(self, confidence):
-        coco_config.DETECTION_MIN_CONFIDENCE = confidence
+        if confidence is not None:
+            coco_config.DETECTION_MIN_CONFIDENCE = confidence
 
     
     def select_target_classes(self,BG = False, person=False, bicycle=False, car=False, motorcycle=False, airplane=False,

--- a/pixellib/instance.py
+++ b/pixellib/instance.py
@@ -59,6 +59,9 @@ class instance_segmentation():
         self.model = MaskRCNN(mode = "inference", model_dir = self.model_dir, config = coco_config)
         self.model.load_weights(model_path, by_name= True)
 
+    def set_detection_confidence(self, confidence):
+        coco_config.DETECTION_MIN_CONFIDENCE = confidence
+
     
     def select_target_classes(self,BG = False, person=False, bicycle=False, car=False, motorcycle=False, airplane=False,
                       bus=False, train=False, truck=False, boat=False, traffic_light=False, fire_hydrant=False,


### PR DESCRIPTION
Dear Ayoola,

Thanks for creating pixellib! I have a small pull request to change the detection threshold for the instance segmentation.

If you accept the pull request, I will be able to call pixellib with:
```python
segment_video = instance_segmentation()
segment_video.set_detection_confidence(0.1) # new strategy
segment_video.load_model("mask_rcnn_coco.h5")
segment_video.segmentImage("frame.png", output_image_name = "out.jpg")
``` 
Please let me know if you want me to make any changes. Best regards, Daniel
