### PR TITLE
Fix broken dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 numpy 
-pillow
+pillow==9.0.0
 scipy
 opencv-python
 scikit-image
 tensorflow
 imgaug
 matplotlib
-labelme2coco
+labelme2coco==0.1.2


### PR DESCRIPTION
The new versions of `labelme2coco` is causing issues, like: [121](https://github.com/ayoolaolafenwa/PixelLib/issues/121), [128](https://github.com/ayoolaolafenwa/PixelLib/issues/128) and [137](https://github.com/ayoolaolafenwa/PixelLib/issues/137).
The newest version of Pillow causes the error: `module 'pil.image' has no attribute 'resampling'` [122](https://github.com/ayoolaolafenwa/PixelLib/issues/122).

Just accepting this PR, these issues will be fixed.