### PR TITLE
FIX #143 - issues with labelme2coco Dataset in MaskRCNN custom train

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vs/
+.vscode/
+__pycache__/
+pixellib.egg-info/
+CustomTrainExample.ipynb

--- a/Tutorials/custom_train.md
+++ b/Tutorials/custom_train.md
@@ -5,21 +5,43 @@ Implement custom training on your own dataset using PixelLib's Library. In just 
 # Prepare your dataset
 
 Our goal is to create a model that can perform instance segmentation and object detection on butterflies and squirrels.
-Collect images for the objects you want to detect and annotate your dataset for custom training. Labelme is the tool employed to perform polygon annotation of objects. Create a root directory or folder and within it create train and test folder. Separate the images required for training (a minimum of 300) and test.Put the images you want to use for training in the train folder and put the images you want to use for testing in the test folder. You will annotate both images in the train and test folder. Download [Nature's dataset](https://github.com/ayoolaolafenwa/PixelLib/releases/download/1.0.0/Nature.zip) used as a sample dataset in this article, unzip it to extract the images' folder. This dataset will serve as a guide for you to know how to organize your images.Ensure that the format of the directory of your own dataset directory is not different from it. Nature is a dataset with two categories butterfly and squirrel. There is 300 images for each class for training and 100 images for each class for testing i.e 600 images for training and 200 images for validation. Nature is a dataset with 800 images. 
+Collect images for the objects you want to detect and annotate your dataset for custom training. Labelme is the tool employed to perform polygon annotation of objects. Create a root directory or folder and within it create train and test folder. Separate the images required for training (a minimum of 300) and test.Put the images you want to use for training in the train folder and put the images you want to use for testing in the test folder. You will annotate both images in the train and test folder. Download [Nature's dataset](https://github.com/ayoolaolafenwa/PixelLib/releases/download/1.0.0/Nature.zip) used as a sample dataset in this article, unzip it to extract the images' folder. This dataset will serve as a guide for you to know how to organize your images.Ensure that the format of the directory of your own dataset directory is not different from it. Nature is a dataset with two categories butterfly and squirrel. There is 300 images for each class for training and 100 images for each class for testing i.e 600 images for training and 200 images for validation. Nature is a dataset with 800 images.
 
-## Labelme annotation tool is employed to perform polygon annotation of objects, read this article on [medium](https://medium.com/@olafenwaayoola/image-annotation-with-labelme-81687ac2d077) on how to annotate objects with Labelme. 
+### NOTE: Fixing the sample Nature Dataset
+There's some minor data integrity errors in the sample dataset, as [reported and addressed here](https://github.com/ayoolaolafenwa/PixelLib/issues/143)
 
-``` 
+You can fix the issue by running the following starter code:
+
+```python
+import json
+import os
+from tqdm import tqdm
+DATA_DIR = "Datasets/Nature"
+for _dir in os.listdir(f"{DATA_DIR}"):
+    DATA_SET = f"{DATA_DIR}/{_dir}"
+    for file in tqdm(os.listdir(DATA_SET)):
+        if file.endswith(".json"):
+            with open(os.path.join(DATA_SET, file), 'r') as f:
+                data = json.load(f)
+            data['imagePath'] = data['imagePath'].replace(
+                '..\\', '').replace("images\\", "")
+            with open(os.path.join(DATA_SET, file), 'w') as f:
+                json.dump(data, f)
+```
+
+## Labelme annotation tool is employed to perform polygon annotation of objects, read this article on [medium](https://medium.com/@olafenwaayoola/image-annotation-with-labelme-81687ac2d077) on how to annotate objects with Labelme.
+
+```
 Nature >>train>>>>>>>>>>>> image1.jpg
                            image1.json
                            image2.jpg
                            image2.json
-      
+
        >>test>>>>>>>>>>>>  img1.jpg
                            img1.json
                            img2.jpg
-                           img2.json   
-```                           
+                           img2.json
+```
 
 Sample of folder directory after annotation.
 
@@ -27,7 +49,7 @@ Sample of folder directory after annotation.
 
 Visualize a sample image before training to confirm that the masks and bounding boxes are well generated.
 
-```python 
+```python
 
    import pixellib
    from pixellib.custom_train import instance_custom_training
@@ -47,7 +69,7 @@ Visualize a sample image before training to confirm that the masks and bounding 
 We imported in pixellib, from pixellib import the class instance_custom_training and created an instance of the class. 
 
 ```python
-   
+
    vis_img.load_dataset("Nature")
 ```
 
@@ -59,12 +81,12 @@ Nature >>>>>>>>train>>>>>>>>>>>>>>> image1.jpg
                train.json           image1.json
                                     image2.jpg
                                     image2.json
-                                 
+
        >>>>>>>>>>>test>>>>>>>>>>>>>>> img1.jpg
                   test.json           img1.json
                                       img2.jpg
                                       img2.json
-```                                      
+```
 
 
 Inside the load_dataset function annotations are extracted from the jsons's files. Bitmap masks are generated from the polygon points of the annotations and bounding boxes are generated from the masks. The smallest box that encapsulates all the pixels of the mask is used as a bounding box.
@@ -104,8 +126,8 @@ This is the code for performing training, in just seven lines of code you train 
 
 ```python
 
-  train_maskrcnn.modelConfig(network_backbone = "resnet101", num_classes= 2, batch_size = 4) 
-```                        
+  train_maskrcnn.modelConfig(network_backbone = "resnet101", num_classes= 2, batch_size = 4)
+```
 We called the function modelConfig, i.e model's configuration. It takes the following parameters:
 
 **network_backbone:** This the CNN network used as a feature extractor for mask-rcnn. The feature extractor used is resnet101.
@@ -125,7 +147,7 @@ We are going to employ the technique of transfer learning for training the model
 Download coco model from [here](https://github.com/ayoolaolafenwa/PixelLib/releases/download/1.2/mask_rcnn_coco.h5)
 
 ```python
-   
+
    train_maskrcnn.train_model(num_epochs = 300, augmentation=True,path_trained_models = "mask_rcnn_models")
 ```
 
@@ -133,13 +155,13 @@ Finally, we called the train function for training maskrcnn model. We called *tr
 
 **num_epochs:** The number of epochs required for training the model. It is set to 300.
 
-**augmentation:** 
+**augmentation:**
 
-[Data Augmentation](https://towardsdatascience.com/data-augmentation-for-deep-learning-4fe21d1a4eb9) is applied on the dataset, this is because we want the model to learn different representations of the objects.  
-Often performed when you have a small dataset, you can improve evaluation scores using this technique.  
+[Data Augmentation](https://towardsdatascience.com/data-augmentation-for-deep-learning-4fe21d1a4eb9) is applied on the dataset, this is because we want the model to learn different representations of the objects.
+Often performed when you have a small dataset, you can improve evaluation scores using this technique.
 PixelLib now supports a custom `imgaug` augmentation pipeline. You can read the [imgaug docs](https://imgaug.readthedocs.io/) and perform augmentation as :
 ```python
-   
+
    import imgaug as ia
    import imgaug.augmenters as iaa
    # Define our augmentation pipeline.
@@ -151,9 +173,9 @@ PixelLib now supports a custom `imgaug` augmentation pipeline. You can read the 
    train_maskrcnn.train_model(num_epochs = 300, augmentation=augmentation_sequence_pipeline,path_trained_models = "mask_rcnn_models")
 ```
 
-**Note** This is the default imgaug augmentation values used by PixelLib when the **augmentation** parameter is set to **True** in the **train_model** function. 
+**Note** This is the default imgaug augmentation values used by PixelLib when the **augmentation** parameter is set to **True** in the **train_model** function.
 ```python
-   
+
 augmentation = imgaug.augmenters.Sometimes(0.5, [
 			        imgaug.augmenters.Fliplr(0.5),
 			        iaa.Flipud(0.5),
@@ -168,9 +190,9 @@ If all of this is too intimidating, you can just set `augmentation=True` and you
 
 ```
 Using resnet101 as network backbone For Mask R-CNN model
-Train 600 images 
-Validate 200 images 
-Applying augmentation on dataset 
+Train 600 images
+Validate 200 images
+Applying augmentation on dataset
 Checkpoint Path: mask_rcnn_models
 Selecting layers to train
 Epoch 1/200
@@ -197,14 +219,14 @@ Google colab: Google Colab provides a single 12GB NVIDIA Tesla K80 GPU that can 
 
 **Using Resnet101:** Training Mask-RCNN consumes alot of memory. On google colab using resnet101 as network backbone you will be able to train with a batchsize of 4. The default network backbone is resnet101. Resnet101 is used as a default backbone because it appears to reach a lower validation loss during training faster than resnet50. It also works better for a dataset with multiple classes and much more images.
 
-**Using Resnet50:** The advantage with resnet50 is that it consumes lesser memory, you can use a batch_size of 6 or 8 on google colab depending on how colab randomly allocates gpu. 
+**Using Resnet50:** The advantage with resnet50 is that it consumes lesser memory, you can use a batch_size of 6 or 8 on google colab depending on how colab randomly allocates gpu.
 The modified code supporting resnet50 will be like this.
 
 
 Full code
 
 ``` python
-   
+
    import pixellib
    from pixellib.custom_train import instance_custom_training
 
@@ -229,13 +251,13 @@ It shows that we are using *resnet50* for training.
 
 
 **Note:** The batch_sizes given are samples used for google colab. If you are using a less powerful GPU, reduce your batch size, for example a PC with a 4G RAM GPU you should use a batch size of 1 for both resnet50 or resnet101. I used a batch size of 1 to train my model on my PC's GPU, train for less than 100 epochs and it produced a validation loss of 0.263. This is favourable because my dataset is not large. A PC with a more powerful GPU you can use a batch size of 2. If you have a large dataset with more classes and much more images use google colab where you have free access to a single 12GB NVIDIA Tesla K80 GPU that can be used up to 12 hours continuously. Most importantly try and use a more powerful GPU and train for more epochs to produce a custom model that will perform efficiently across multiple classes. Achieve better results by training with much more images. 300 images for each each class is recommended to be the minimum required for training.
- 
+
 # Model Evaluation
 
-When we are done with training we should evaluate models with lowest validation losses. Model evaluation is used to access the performance of the trained model on the test dataset.The model trained on Nature dataset and the dataset are available on the [release](https://github.com/ayoolaolafenwa/PixelLib/releases) of this github's repository. Download the trained model from [here](https://github.com/ayoolaolafenwa/PixelLib/releases/download/1.0.0/Nature_model_resnet101.h5). 
+When we are done with training we should evaluate models with lowest validation losses. Model evaluation is used to access the performance of the trained model on the test dataset.The model trained on Nature dataset and the dataset are available on the [release](https://github.com/ayoolaolafenwa/PixelLib/releases) of this github's repository. Download the trained model from [here](https://github.com/ayoolaolafenwa/PixelLib/releases/download/1.0.0/Nature_model_resnet101.h5).
 
 ```python
-  
+
   import pixellib
   from pixellib.custom_train import instance_custom_training
 
@@ -256,7 +278,7 @@ The mAP(Mean Avearge Precision) of the model is *0.89*.
 You can evaluate multiple models at once, what you just need is to pass in the folder directory of the models.
 
 ```python
-  
+
   import pixellib
   from pixellib.custom_train import instance_custom_training
 
@@ -280,7 +302,7 @@ mask_rcnn_models\mask_rcnn_model_058.h5 evaluation using iou_threshold 0.5 is 0.
 
 
 ```python
-  
+
   import pixellib
   from pixellib.custom_train import instance_custom_training
 

--- a/pixellib/custom_train/__init__.py
+++ b/pixellib/custom_train/__init__.py
@@ -1,46 +1,54 @@
+import colorsys
+import json
 import os
-import numpy as np
-import skimage.draw
-import pixellib.instance.mask_rcnn as modellib
-from pixellib.instance.utils import Dataset
-import numpy as np
-from numpy import zeros
 import random
-import cv2
 import time
-import tensorflow 
-from pixellib.instance.utils import Dataset
-from pixellib.instance.utils import compute_ap
-from pixellib.instance.mask_rcnn import mold_image
+
+import cv2
+import imageio
 import imgaug
 import imgaug as ia
-import imageio
 import imgaug.augmenters as iaa
-import matplotlib.pyplot as plt
-from pixellib.instance.mask_rcnn import MaskRCNN
-from pixellib.instance.mask_rcnn import load_image_gt
-from pixellib.instance.mask_rcnn import log
-from pixellib.instance.utils import extract_bboxes
-from pixellib.instance.utils import Dataset
-from pixellib.instance.config import Config
-from PIL import Image, ImageDraw
-import json
 import labelme2coco
+import matplotlib.pyplot as plt
+import numpy as np
+import pixellib.instance.mask_rcnn as modellib
+import skimage.draw
+import tensorflow
+from numpy import zeros
+from PIL import Image, ImageDraw
 from pixellib.instance.config import Config
-from pixellib.instance.mask_rcnn import log
-import colorsys
-
+from pixellib.instance.mask_rcnn import MaskRCNN, load_image_gt, log, mold_image
+from pixellib.instance.utils import Dataset, compute_ap, extract_bboxes
 
 
 class instance_custom_training:
     def __init__(self):
         self.model_dir = os.getcwd()
 
-        
-    def modelConfig(self,network_backbone = "resnet101",  num_classes =  1,  class_names = ["BG"], batch_size = 1, detection_threshold = 0.7, image_max_dim = 512, image_min_dim = 512, image_resize_mode ="square", gpu_count = 1):
-        self.config = Config(BACKBONE = network_backbone, NUM_CLASSES = 1 +  num_classes,  class_names = class_names, 
-       IMAGES_PER_GPU = batch_size, IMAGE_MAX_DIM = image_max_dim, IMAGE_MIN_DIM = image_min_dim, DETECTION_MIN_CONFIDENCE = detection_threshold,
-       IMAGE_RESIZE_MODE = image_resize_mode,GPU_COUNT = gpu_count)
+    def modelConfig(
+        self,
+        network_backbone="resnet101",
+        num_classes=1,
+        class_names=["BG"],
+        batch_size=1,
+        detection_threshold=0.7,
+        image_max_dim=512,
+        image_min_dim=512,
+        image_resize_mode="square",
+        gpu_count=1,
+    ):
+        self.config = Config(
+            BACKBONE=network_backbone,
+            NUM_CLASSES=1 + num_classes,
+            class_names=class_names,
+            IMAGES_PER_GPU=batch_size,
+            IMAGE_MAX_DIM=image_max_dim,
+            IMAGE_MIN_DIM=image_min_dim,
+            DETECTION_MIN_CONFIDENCE=detection_threshold,
+            IMAGE_RESIZE_MODE=image_resize_mode,
+            GPU_COUNT=gpu_count,
+        )
 
         if network_backbone == "resnet101":
             print("Using resnet101 as network backbone For Mask R-CNN model")
@@ -48,41 +56,53 @@ class instance_custom_training:
             print("Using resnet50 as network backbone For Mask R-CNN model")
 
     def load_pretrained_model(self, model_path):
-        #load the weights for COCO
-        self.model = modellib.MaskRCNN(mode="training", model_dir = self.model_dir, config = self.config)
-        self.model.load_weights(model_path, by_name=True, exclude=["mrcnn_class_logits", "mrcnn_bbox_fc",  "mrcnn_bbox", 
-        "mrcnn_mask"])
-    
-    
-    def load_dataset(self, dataset):
+        # load the weights for COCO
+        self.model = modellib.MaskRCNN(
+            mode="training", model_dir=self.model_dir, config=self.config
+        )
+        self.model.load_weights(
+            model_path,
+            by_name=True,
+            exclude=["mrcnn_class_logits", "mrcnn_bbox_fc", "mrcnn_bbox", "mrcnn_mask"],
+        )
+
+    def load_dataset(self, dataset, train_split_rate=1):
         labelme_folder1 = os.path.abspath(os.path.join(dataset, "train"))
 
-        #dir where the converted json files will be saved
-        save_json_path1 = os.path.abspath(os.path.join(dataset, "train.json"))
-        
-        #conversion of individual labelme json files into a single json file        
+        # dir where the converted json files will be saved
+        save_json_path1 = os.path.abspath(dataset)
+
+        # conversion of individual labelme json files into a single json file
         labelme2coco.convert(labelme_folder1, save_json_path1)
-        
+
+        if train_split_rate == 1:
+            save_json_path1 = os.path.abspath(
+                os.path.join(save_json_path1, "dataset.json")
+            )
+        else:
+            save_json_path1 = os.path.abspath(
+                os.path.join(save_json_path1, "train.json")
+            )
+
         # Training dataset.
         self.dataset_train = Data()
         self.dataset_train.load_data(save_json_path1, labelme_folder1)
         self.dataset_train.prepare()
-        
-        
+
         labelme_folder2 = os.path.abspath(os.path.join(dataset, "test"))
 
-        #dir where the converted json files will be saved
-        save_json_path2 = os.path.abspath(os.path.join(dataset, "test.json"))
-        
-        
-        #conversion of individual labelme json files into a single json file  
+        # dir where the converted json files will be saved
+        save_json_path2 = os.path.abspath(dataset)
+
+        # conversion of individual labelme json files into a single json file
         labelme2coco.convert(labelme_folder2, save_json_path2)
-        
+
+        save_json_path2 = os.path.abspath(os.path.join(save_json_path2, "dataset.json"))
+
         # Training dataset.
         self.dataset_test = Data()
         self.dataset_test.load_data(save_json_path2, labelme_folder2)
         self.dataset_test.prepare()
-    
 
     def visualize_sample(self):
         image_id = np.random.choice(self.dataset_train.image_ids)
@@ -91,86 +111,113 @@ class instance_custom_training:
         mask, class_ids = self.dataset_train.load_mask(image_id)
         bbox = extract_bboxes(mask)
 
-
         # Display image and instances
-        out = display_box_instances(image, bbox, mask, class_ids, self.dataset_train.class_names)  
+        out = display_box_instances(
+            image, bbox, mask, class_ids, self.dataset_train.class_names
+        )
         plt.imshow(out)
         plt.axis("off")
         plt.show()
-            
 
-        
-
-    def train_model(self, num_epochs, path_trained_models,  layers = "all", augmentation = False):
+    def train_model(
+        self, num_epochs, path_trained_models, layers="all", augmentation=False
+    ):
         if augmentation == False:
             print("No Augmentation")
 
         else:
             if augmentation == True:
-                augmentation = imgaug.augmenters.Sometimes(0.5, [
-			        imgaug.augmenters.Fliplr(0.5),
-			        iaa.Flipud(0.5),
-			        imgaug.augmenters.GaussianBlur(sigma=(0.0, 5.0))
-			        ])
+                augmentation = imgaug.augmenters.Sometimes(
+                    0.5,
+                    [
+                        imgaug.augmenters.Fliplr(0.5),
+                        iaa.Flipud(0.5),
+                        imgaug.augmenters.GaussianBlur(sigma=(0.0, 5.0)),
+                    ],
+                )
                 print("Applying Default Augmentation on Dataset")
 
             else:
                 augmentation = augmentation
-                print("Applying Custom Augmentation on Dataset")   
+                print("Applying Custom Augmentation on Dataset")
 
-        print('Train %d' % len(self.dataset_train.image_ids), "images")
-        print('Validate %d' % len(self.dataset_test.image_ids), "images")
+        print("Train %d" % len(self.dataset_train.image_ids), "images")
+        print("Validate %d" % len(self.dataset_test.image_ids), "images")
 
-        self.model.train(self.dataset_train, self.dataset_test,models = path_trained_models, augmentation = augmentation, 
-        epochs=num_epochs,layers=layers)
-                             
-        
-    def evaluate_model(self, model_path, iou_threshold = 0.5):
-        self.model = MaskRCNN(mode = "inference", model_dir = os.getcwd(), config = self.config)  
+        self.model.train(
+            self.dataset_train,
+            self.dataset_test,
+            models=path_trained_models,
+            augmentation=augmentation,
+            epochs=num_epochs,
+            layers=layers,
+        )
+
+    def evaluate_model(self, model_path, iou_threshold=0.5):
+        self.model = MaskRCNN(
+            mode="inference", model_dir=os.getcwd(), config=self.config
+        )
         if os.path.isfile(model_path):
             model_files = [model_path]
-             
+
         if os.path.isdir(model_path):
-            model_files = sorted([os.path.join(model_path, file_name) for file_name in os.listdir(model_path)])
+            model_files = sorted(
+                [
+                    os.path.join(model_path, file_name)
+                    for file_name in os.listdir(model_path)
+                ]
+            )
         for modelfile in model_files:
             if str(modelfile).endswith(".h5"):
                 self.model.load_weights(modelfile, by_name=True)
             APs = []
-            #outputs = list()
-            for image_id in self.dataset_test.image_ids:                                                                                                                                                                                                                                                                                                                                                                             
+            # outputs = list()
+            for image_id in self.dataset_test.image_ids:
                 # load image, bounding boxes and masks for the image id
-                image, image_meta, gt_class_id, gt_bbox, gt_mask = load_image_gt(self.dataset_test, self.config, image_id)
+                image, image_meta, gt_class_id, gt_bbox, gt_mask = load_image_gt(
+                    self.dataset_test, self.config, image_id
+                )
                 # convert pixel values (e.g. center)
                 scaled_image = mold_image(image, self.config)
                 # convert image into one sample
                 sample = np.expand_dims(scaled_image, 0)
-		        # make prediction
+                # make prediction
                 yhat = self.model.detect(sample, verbose=0)
-		        # extract results for first sample
+                # extract results for first sample
                 r = yhat[0]
-		        # calculate statistics, including AP
-                AP, _, _, _ = compute_ap(gt_bbox, gt_class_id, gt_mask, r["rois"], r["class_ids"], r["scores"], r['masks'],
-                iou_threshold=iou_threshold)
-		        # store
+                # calculate statistics, including AP
+                AP, _, _, _ = compute_ap(
+                    gt_bbox,
+                    gt_class_id,
+                    gt_mask,
+                    r["rois"],
+                    r["class_ids"],
+                    r["scores"],
+                    r["masks"],
+                    iou_threshold=iou_threshold,
+                )
+                # store
                 APs.append(AP)
-	        # calculate the mean AP across all images
+            # calculate the mean AP across all images
             mAP = np.mean(APs)
-            print(modelfile, "evaluation using iou_threshold", iou_threshold, "is", f"{mAP:01f}", '\n')
+            print(
+                modelfile,
+                "evaluation using iou_threshold",
+                iou_threshold,
+                "is",
+                f"{mAP:01f}",
+                "\n",
+            )
 
-                    
-        
 
 ############################################################
 #  Dataset
 ############################################################
 
 
-
 class Data(Dataset):
+    def load_data(self, annotation_json, images_path):
 
-
-    def load_data(self,  annotation_json, images_path):
-       
         # Load json from file
         json_file = open(annotation_json)
         coco_json = json.load(json_file)
@@ -178,38 +225,45 @@ class Data(Dataset):
 
         # Add the class names using the base method from utils.Dataset
         source_name = "coco_like_dataset"
-        for category in coco_json['categories']:
-            class_id = category['id']
-            class_name = category['name']
+        for category in coco_json["categories"]:
+            class_id = category["id"] + 1
+            class_name = category["name"]
             if class_id < 1:
-                print('Error: Class id for "{}" cannot be less than one. (0 is reserved for the background)'.format(
-                    class_name))
+                print(
+                    'Error: Class id for "{}" cannot be less than one. (0 is reserved for the background)'.format(
+                        class_name
+                    )
+                )
                 return
 
             self.add_class(source_name, class_id, class_name)
 
         # Get all annotations
         annotations = {}
-        for annotation in coco_json['annotations']:
-            image_id = annotation['image_id']
+        for annotation in coco_json["annotations"]:
+            image_id = annotation["image_id"]
             if image_id not in annotations:
                 annotations[image_id] = []
             annotations[image_id].append(annotation)
 
         # Get all images and add them to the dataset
         seen_images = {}
-        for image in coco_json['images']:
-            image_id = image['id']
+        for image in coco_json["images"]:
+            image_id = image["id"]
             if image_id in seen_images:
                 print("Warning: Skipping duplicate image id: {}".format(image))
             else:
                 seen_images[image_id] = image
                 try:
-                    image_file_name = image['file_name']
-                    image_width = image['width']
-                    image_height = image['height']
+                    image_file_name = image["file_name"]
+                    image_width = image["width"]
+                    image_height = image["height"]
                 except KeyError as key:
-                    print("Warning: Skipping image (id: {}) with missing key: {}".format(image_id, key))
+                    print(
+                        "Warning: Skipping image (id: {}) with missing key: {}".format(
+                            image_id, key
+                        )
+                    )
 
                 image_path = os.path.abspath(os.path.join(images_path, image_file_name))
                 image_annotations = annotations[image_id]
@@ -221,13 +275,11 @@ class Data(Dataset):
                     path=image_path,
                     width=image_width,
                     height=image_height,
-                    annotations=image_annotations
+                    annotations=image_annotations,
                 )
 
-    
-
     def load_mask(self, image_id):
-        """ Load instance masks for the given image.
+        """Load instance masks for the given image.
         MaskRCNN expects masks in the form of a bitmap [height, width, instances].
         Args:
             image_id: The id of the image to load masks for
@@ -237,15 +289,15 @@ class Data(Dataset):
             class_ids: a 1D array of class IDs of the instance masks.
         """
         image_info = self.image_info[image_id]
-        annotations = image_info['annotations']
+        annotations = image_info["annotations"]
         instance_masks = []
         class_ids = []
 
         for annotation in annotations:
-            class_id = annotation['category_id']
-            mask = Image.new('1', (image_info['width'], image_info['height']))
-            mask_draw = ImageDraw.ImageDraw(mask, '1')
-            for segmentation in annotation['segmentation']:
+            class_id = annotation["category_id"]
+            mask = Image.new("1", (image_info["width"], image_info["height"]))
+            mask_draw = ImageDraw.ImageDraw(mask, "1")
+            for segmentation in annotation["segmentation"]:
                 mask_draw.polygon(segmentation, fill=1)
                 bool_array = np.array(mask) > 0
                 instance_masks.append(bool_array)
@@ -254,8 +306,7 @@ class Data(Dataset):
         mask = np.dstack(instance_masks)
         class_ids = np.array(class_ids, dtype=np.int32)
 
-        return mask, class_ids    
-
+        return mask, class_ids
 
 
 def random_colors(N, bright=True):
@@ -272,26 +323,23 @@ def random_colors(N, bright=True):
 
 
 def apply_mask(image, mask, color, alpha=0.5):
-    """Apply the given mask to the image.
-    """
+    """Apply the given mask to the image."""
     for c in range(3):
-        image[:, :, c] = np.where(mask == 1,
-                                  image[:, :, c] *
-                                  (1 - alpha) + alpha * color[c] * 255,
-                                  image[:, :, c])
+        image[:, :, c] = np.where(
+            mask == 1,
+            image[:, :, c] * (1 - alpha) + alpha * color[c] * 255,
+            image[:, :, c],
+        )
     return image
 
 
-    
+def display_instances(image, boxes, masks, class_ids, class_name):
 
-
-def display_instances(image, boxes, masks, class_ids,  class_name):
-    
     n_instances = boxes.shape[0]
     colors = random_colors(n_instances)
 
     if not n_instances:
-        print('NO INSTANCES TO DISPLAY')
+        print("NO INSTANCES TO DISPLAY")
     else:
         assert boxes.shape[0] == masks.shape[-1] == class_ids.shape[0]
 
@@ -300,20 +348,16 @@ def display_instances(image, boxes, masks, class_ids,  class_name):
 
         image = apply_mask(image, mask, color)
 
-
     return image
 
 
+def display_box_instances(image, boxes, masks, class_ids, class_name, scores=None):
 
-
-
-def display_box_instances(image, boxes, masks, class_ids, class_name, scores = None):
-    
     n_instances = boxes.shape[0]
     colors = random_colors(n_instances)
 
     if not n_instances:
-        print('NO INSTANCES TO DISPLAY')
+        print("NO INSTANCES TO DISPLAY")
     else:
         assert boxes.shape[0] == masks.shape[-1] == class_ids.shape[0]
 
@@ -324,16 +368,19 @@ def display_box_instances(image, boxes, masks, class_ids, class_name, scores = N
         y1, x1, y2, x2 = boxes[i]
         label = class_name[class_ids[i]]
         score = scores[i] if scores is not None else None
-        caption = '{} {:.2f}'.format(label, score) if score else label
+        caption = "{} {:.2f}".format(label, score) if score else label
         mask = masks[:, :, i]
 
         image = apply_mask(image, mask, color)
         color_rec = [int(c) for c in np.array(colors[i]) * 255]
         image = cv2.rectangle(image, (x1, y1), (x2, y2), color_rec, 2)
         image = cv2.putText(
-            image, caption, (x1, y1), cv2.FONT_HERSHEY_COMPLEX, 0.5, color = (255, 255, 255))
+            image,
+            caption,
+            (x1, y1),
+            cv2.FONT_HERSHEY_COMPLEX,
+            0.5,
+            color=(255, 255, 255),
+        )
 
     return image
-
-
-


### PR DESCRIPTION
This fixes [#143](https://github.com/ayoolaolafenwa/PixelLib/issues/143) 

Fixes include:

1.  Make load_dataset compatible with `labelme2coco.convert()`
2. Ensures that labelme2coco.convert() respects the 0 class ID reservation and avoid throwing: 
```python 
if class_id < 1:
print(
'Error: Class id for "{}" cannot be less than one. (0 is reserved for the background)'.format(class_name)
)
````
3. Updates docs for [custom train example](https://github.com/ayoolaolafenwa/PixelLib/blob/master/Tutorials/custom_train.md)