### PR TITLE
Removed deprecated np.bool and replaced it with bool type

### DIFF
--- a/pixellib/instance/mask_rcnn.py
+++ b/pixellib/instance/mask_rcnn.py
@@ -1241,14 +1241,14 @@ def load_image_gt(dataset,  config, image_id, augmentation=False, training = Fal
         # Make augmenters deterministic to apply similarly to images and masks
         det = augmentation.to_deterministic()
         image = det.augment_image(image)
-        # Change mask to np.uint8 because imgaug doesn't support np.bool
+        # Change mask to np.uint8 because imgaug doesn't support bool
         mask = det.augment_image(mask.astype(np.uint8),
                                  hooks=imgaug.HooksImages(activator=hook))
         # Verify that shapes didn't change
         assert image.shape == image_shape, "Augmentation shouldn't change image size"
         assert mask.shape == mask_shape, "Augmentation shouldn't change mask size"
         # Change mask back to bool
-        mask = mask.astype(np.bool)
+        mask = mask.astype(bool)
 
     # Note that some boxes might be all zeros if the corresponding mask got cropped out.
     # and here is to filter them out
@@ -1306,7 +1306,7 @@ def build_detection_targets(rpn_rois, gt_class_ids, gt_boxes, gt_masks, config):
         gt_class_ids.dtype)
     assert gt_boxes.dtype == np.int32, "Expected int but got {}".format(
         gt_boxes.dtype)
-    assert gt_masks.dtype == np.bool_, "Expected bool but got {}".format(
+    assert gt_masks.dtype == bool_, "Expected bool but got {}".format(
         gt_masks.dtype)
 
     # It's common to add GT Boxes to ROIs but we don't do that here because

--- a/pixellib/instance/utils.py
+++ b/pixellib/instance/utils.py
@@ -527,7 +527,7 @@ def minimize_mask(bbox, mask, mini_shape):
             raise Exception("Invalid bounding box with area of zero")
         # Resize with bilinear interpolation
         m = resize(m, mini_shape)
-        mini_mask[:, :, i] = np.around(m).astype(np.bool)
+        mini_mask[:, :, i] = np.around(m).astype(bool)
     return mini_mask
 
 
@@ -544,7 +544,7 @@ def expand_mask(bbox, mini_mask, image_shape):
         w = x2 - x1
         # Resize with bilinear interpolation
         m = resize(m, (h, w))
-        mask[y1:y2, x1:x2, i] = np.around(m).astype(np.bool)
+        mask[y1:y2, x1:x2, i] = np.around(m).astype(bool)
     return mask
 
 
@@ -563,10 +563,10 @@ def unmold_mask(mask, bbox, image_shape):
     threshold = 0.5
     y1, x1, y2, x2 = bbox
     mask = resize(mask, (y2 - y1, x2 - x1))
-    mask = np.where(mask >= threshold, 1, 0).astype(np.bool)
+    mask = np.where(mask >= threshold, 1, 0).astype(bool)
 
     # Put the mask in the right location.
-    full_mask = np.zeros(image_shape[:2], dtype=np.bool)
+    full_mask = np.zeros(image_shape[:2], dtype=bool)
     full_mask[y1:y2, x1:x2] = mask
     return full_mask
 

--- a/pixellib/torchbackend/instance/structures/masks.py
+++ b/pixellib/torchbackend/instance/structures/masks.py
@@ -31,7 +31,7 @@ def polygons_to_bitmask(polygons: List[np.ndarray], height: int, width: int) -> 
     assert len(polygons) > 0, "COCOAPI does not support empty polygons"
     rles = mask_util.frPyObjects(polygons, height, width)
     rle = mask_util.merge(rles)
-    return mask_util.decode(rle).astype(np.bool)
+    return mask_util.decode(rle).astype(bool)
 
 
 def rasterize_polygons_within_box(
@@ -336,7 +336,7 @@ class PolygonMasks:
                 a BoolTensor which represents whether each mask is empty (False) or not (True).
         """
         keep = [1 if len(polygon) > 0 else 0 for polygon in self.polygons]
-        return torch.from_numpy(np.asarray(keep, dtype=np.bool))
+        return torch.from_numpy(np.asarray(keep, dtype=bool))
 
     def __getitem__(self, item: Union[int, slice, List[int], torch.BoolTensor]) -> "PolygonMasks":
         """

--- a/pixellib/torchbackend/instance/utils/video_visualizer.py
+++ b/pixellib/torchbackend/instance/utils/video_visualizer.py
@@ -187,7 +187,7 @@ class VideoVisualizer:
         """
 
         # Compute iou with either boxes or masks:
-        is_crowd = np.zeros((len(instances),), dtype=np.bool)
+        is_crowd = np.zeros((len(instances),), dtype=bool)
         if instances[0].bbox is None:
             assert instances[0].mask_rle is not None
             # use mask iou only when box iou is None

--- a/pixellib/torchbackend/instance/utils/visualizer.py
+++ b/pixellib/torchbackend/instance/utils/visualizer.py
@@ -215,7 +215,7 @@ class _PanopticPrediction:
         assert (
             len(empty_ids) == 1
         ), ">1 ids corresponds to no labels. This is currently not supported"
-        return (self._seg != empty_ids[0]).numpy().astype(np.bool)
+        return (self._seg != empty_ids[0]).numpy().astype(bool)
 
     def semantic_masks(self):
         for sid in self._seg_ids:
@@ -223,14 +223,14 @@ class _PanopticPrediction:
             if sinfo is None or sinfo["isthing"]:
                 # Some pixels (e.g. id 0 in PanopticFPN) have no instance or semantic predictions.
                 continue
-            yield (self._seg == sid).numpy().astype(np.bool), sinfo
+            yield (self._seg == sid).numpy().astype(bool), sinfo
 
     def instance_masks(self):
         for sid in self._seg_ids:
             sinfo = self._sinfo.get(sid)
             if sinfo is None or not sinfo["isthing"]:
                 continue
-            mask = (self._seg == sid).numpy().astype(np.bool)
+            mask = (self._seg == sid).numpy().astype(bool)
             if mask.sum() > 0:
                 yield mask, sinfo
 


### PR DESCRIPTION
## Changes Made
• Removed the deprecated np.bool type from the codebase.
• Replaced instances of np.bool with the built-in bool type.

## Context
The use of np.bool has been deprecated, and it is recommended to use the native bool type in Python. This pull request addresses this deprecation by removing all occurrences of np.bool and updating them to use bool instead. This ensures code compatibility with the latest best practices and avoids potential issues related to deprecated types.
