### PR TITLE
fix bug - update 'deeplab.py' #180 #181

### DIFF
--- a/pixellib/semantic/deeplab.py
+++ b/pixellib/semantic/deeplab.py
@@ -4,21 +4,25 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-from tensorflow.python.keras.models import Model
-from tensorflow.python.keras import layers
-from tensorflow.python.keras.layers import Input
-from tensorflow.python.keras.layers import Lambda
-from tensorflow.python.keras.layers import Activation
-from tensorflow.python.keras.layers import Concatenate
-from tensorflow.python.keras.layers import Add
-from tensorflow.python.keras.layers import Dropout
-from tensorflow.python.keras.layers import BatchNormalization
-from tensorflow.python.keras.layers import Conv2D
-from tensorflow.python.keras.layers import DepthwiseConv2D
-from tensorflow.python.keras.layers import ZeroPadding2D
-from tensorflow.python.keras.layers import GlobalAveragePooling2D
+from tensorflow.keras.models import Model
+from tensorflow.keras import layers
+from tensorflow.keras.layers import Input
+from tensorflow.keras.layers import Lambda
+from tensorflow.keras.layers import Activation
+from tensorflow.keras.layers import Concatenate
+from tensorflow.keras.layers import Add
+from tensorflow.keras.layers import Dropout
+from tensorflow.keras.layers import BatchNormalization
+from tensorflow.keras.layers import Conv2D
+from tensorflow.keras.layers import DepthwiseConv2D
+from tensorflow.keras.layers import ZeroPadding2D
+from tensorflow.keras.layers import GlobalAveragePooling2D
 from tensorflow.python.keras.utils.layer_utils import get_source_inputs
 from tensorflow.keras import backend as K
+
+class ShapeLayer(tf.keras.Layer):
+        def call(self, x):
+            return tf.shape(x)
 
 config = tf.compat.v1.ConfigProto()
 config.gpu_options.allow_growth = True
@@ -196,10 +200,10 @@ def Deeplab_xcep_pascal(weights=None, input_tensor=None, input_shape=(512, 512, 
         x = _xception_block(x, [1536, 1536, 2048], 'exit_flow_block2',
                             skip_connection_type='none', stride=1, rate=exit_block_rates[1],
                             depth_activation=True)
-
     
-
-    shape_before = tf.shape(x)
+    
+    
+    shape_before = ShapeLayer()(x)
     b4 = GlobalAveragePooling2D()(x)
     # from (b_size, channels)->(b_size, 1, 1, channels)
     b4 = Lambda(lambda x: K.expand_dims(x, 1))(b4)
@@ -379,10 +383,10 @@ def Deeplab_xcep_ade20k(weights=None, input_tensor=None, input_shape=(512, 512, 
         x = _xception_block(x, [1536, 1536, 2048], 'exit_flow_block2',
                             skip_connection_type='none', stride=1, rate=exit_block_rates[1],
                             depth_activation=True)
+        
 
     
-
-    shape_before = tf.shape(x)
+    shape_before = ShapeLayer()(x)
     b4 = GlobalAveragePooling2D()(x)
     # from (b_size, channels)->(b_size, 1, 1, channels)
     b4 = Lambda(lambda x: K.expand_dims(x, 1))(b4)


### PR DESCRIPTION
With minor tweaks, the semantic segmentation is compatible with recent TensorFlow and Keras.
The PixelLib project seems to be on a halt, but for anyone who steps here, I hope this helps.

The errors I faced were... (every job was held in `semantic/deeplab.py`)
- `ImportError: cannot import name '...' from 'tensorflow.python.keras.layers'`<br>→ change `tensorflow.python.keras.layers` to `tensorflow.keras.layers`
- `ValueError: A KerasTensor cannot be used as input to a TensorFlow function.`<br>(on code `shape_before = tf.shape(x)`) <br>→ add Keras Layer subclass and use it to return the shape (`x` is KerasTensor and `shape()` is TensorFlow function)
- `AttributeError: 'KerasHistory' object has no attribute 'layer'`<br>→ change `tensorflow.python.keras.models` to `tensorflow.keras.models`


Additionally, I'm on Apple Silicon with the versions below.

> - Python 3.12.4
> - tensorflow==2.17.0
> - pixellib==0.7.1